### PR TITLE
Display Evaluation Result as LaTeX

### DIFF
--- a/main.py
+++ b/main.py
@@ -259,6 +259,53 @@ async def main():
                     await send_message(
                         f"![LaTeX](http://tex.z-dn.net/?f={quote(msg.text[7:])})", bot_chat
                     )
+                    
+                # Evaluate and LaTeX combined
+                elif msg.text.lower().startswith("!evalatex"):
+                    elif msg.text.lower().startswith("!evaluate"):
+                    inputs = [value.strip() for value in msg.text[10:].split(";")]
+                    console.log(
+                        f"Evaluating {'; '.join(inputs)} for {user.get_username()}"
+                    )
+                    try:
+                        expression = math_parser.parse(inputs[0])
+                    except:
+                        console.log("[red]An error occurred during parsing")
+                        await send_message(
+                            "An error occurred while trying to parse your input.",
+                            bot_chat,
+                        )
+                        return
+
+                    variables = expression.variables()
+                    if len(inputs) - 1 != len(variables):
+                        console.log("[red]Incorrect number of variables provided")
+                        await send_message(
+                            f"You have not provided the correct number of variables. (Expected {len(variables)})",
+                            bot_chat,
+                        )
+                        return
+
+                    values = dict(
+                        zip(variables, [float(value) for value in inputs[1:]])
+                    )
+
+                    try:
+                        result = expression.evaluate(values)
+                    except:
+                        console.log("[red]An error occurred during evaluation")
+                        await send_message(
+                            "An error occurred while trying to evaluate your input.",
+                            bot_chat,
+                        )
+                        return
+                    
+                    
+                    await send_message(
+                        f"![LaTeX](http://tex.z-dn.net/?f={quote(result)})", bot_chat
+                    )
+                           
+                
                 # Restart the bot
                 elif msg.text.lower().startswith("!restart"):
                     if user in bot_admins:


### PR DESCRIPTION
 
Closes #91 

## Summary
Added a command so that when the term !evalatex is used, the result of the evaluation is displayed as LaTeX.

<!-- For each item below, replace the [ ] with [x] to confirm that item was completed. -->
## Checklist
- [x] I have read and agree to follow the contributing guidelines and code of conduct in `CONTRIBUTING.md`.
- [x] An issue was made and assigned to me by a maintainer before opening this pull request.
- [x] I have formatted the code as detailed in `CONTRIBUTING.md`.
- [x] I have tested all the code in my pull request, including by running BrainBot as a whole.
