### PR TITLE
Dice Roll

### DIFF
--- a/brainbot.ini.example
+++ b/brainbot.ini.example
@@ -5,5 +5,8 @@ repeat=45
 phon=45
 poll=100
 
+[limits]
+max_dice=99
+
 [misc]
 poll_reactions=zero;one;two;three;four;five;six;seven;eight;nine;keycap_ten

--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
+import random
 from asyncio import get_event_loop
 from configparser import ConfigParser
 from datetime import datetime, timedelta
 from os import getenv, system
 from random import choice
-import random
 from sys import executable
 from urllib.parse import quote
 
@@ -134,7 +134,7 @@ async def main():
                         console.log(
                             f"[bold red]{user.get_username()} attempted to bypass the topic cooldown"
                         )
-                
+
                 # Get a conversation starter
                 elif msg.text.lower().startswith("!topic"):
                     console.log(f"{user.get_username()} used the !topic command")
@@ -165,11 +165,11 @@ async def main():
                         await send_message(f"@{user.get_username()}: {to_do}", bot_chat)
                     else:
                         console.log("Cancelled due to cooldown")
-                
+
                 # Repeat after the user
                 elif msg.text.lower().startswith("!repeat"):
                     msg_text = msg.text[8:]
-                    updatedmsg_text = msg_text.replace("!","\!")
+                    updatedmsg_text = msg_text.replace("!", "\!")
                     console.log(f"Repeating {user.get_username()}")
                     if repeat_cooldown.run(username=user.get_username()):
                         await send_message(
@@ -494,7 +494,7 @@ async def main():
                     """
                     Command usage:  !roll <number>          : Returns same number
                                     !roll d<faces>          : Rolls a single <faces>-faced dice
-                                    !roll <dice>d<faces>    : Rolls the <dice> amount of <faces>-faced dice 
+                                    !roll <dice>d<faces>    : Rolls the <dice> amount of <faces>-faced dice
 
                     Maximum dice and faces are limited by setting limits->max_dice (default: 99)
                     """
@@ -504,35 +504,59 @@ async def main():
                     # Remove any empty arguments
                     while "" in inputs:
                         inputs.remove("")
-                    
+
                     if len(inputs) < 1 or len(inputs) > 2:
-                        await send_message("Please enter a valid dice roll. You can try using: `<dice_number>d<dice_faces>`", bot_chat,)
+                        await send_message(
+                            "Please enter a valid dice roll. You can try using: `<dice_number>d<dice_faces>`",
+                            bot_chat,
+                        )
                     else:
                         try:
                             if any(int(i) > max_dice_limit for i in inputs):
-                                str = "Dice values cannot be greater than the setting: `{0}`".format(max_dice_limit)
-                                await send_message(str, bot_chat, )
+                                str = "Dice values cannot be greater than the setting: `{0}`".format(
+                                    max_dice_limit
+                                )
+                                await send_message(
+                                    str,
+                                    bot_chat,
+                                )
                             elif any(int(i) <= 0 for i in inputs):
-                                await send_message("Dice values cannot be less than 1", bot_chat, )
+                                await send_message(
+                                    "Dice values cannot be less than 1",
+                                    bot_chat,
+                                )
                             else:
                                 roll = 0
                                 str = ""
-                                if len(inputs)==1:
+                                if len(inputs) == 1:
                                     # Casting "!roll <number>" will return same <number>
-                                    if 'd' not in msg.text[6:]:
+                                    if "d" not in msg.text[6:]:
                                         roll = int(inputs[0])
-                                        str = "Rolled `{0}`: `{1}`".format(msg.text[6:], roll)
+                                        str = "Rolled `{0}`: `{1}`".format(
+                                            msg.text[6:], roll
+                                        )
                                         # Print rolled number
-                                        await send_message(str, bot_chat, )
+                                        await send_message(
+                                            str,
+                                            bot_chat,
+                                        )
                                     else:
                                         # Calling "!roll d<number>" will roll a <number>-faced dice
                                         if msg.text[6:].startswith("d"):
-                                            roll = random.randint(1,int(inputs[0]))
-                                            str = "Rolled `{0}`: `{1}`".format(msg.text[6:], roll)
+                                            roll = random.randint(1, int(inputs[0]))
+                                            str = "Rolled `{0}`: `{1}`".format(
+                                                msg.text[6:], roll
+                                            )
                                             # Print rolled number
-                                            await send_message(str, bot_chat, )
+                                            await send_message(
+                                                str,
+                                                bot_chat,
+                                            )
                                         else:
-                                            await send_message("Please enter a valid dice roll. You can try using: `<dice_number>d<dice_faces>`", bot_chat,)
+                                            await send_message(
+                                                "Please enter a valid dice roll. You can try using: `<dice_number>d<dice_faces>`",
+                                                bot_chat,
+                                            )
                                 else:
                                     # Calling "!roll <number1>d<number2>" will roll <number1> dices of <number2> faces each
                                     str = "Rolled `{0}`: `".format(msg.text[6:])
@@ -540,14 +564,20 @@ async def main():
                                         current = random.randint(1, int(inputs[1]))
                                         roll += current
                                         str += "{0}".format(current)
-                                        if i != int(inputs[0])-1:
-                                            str +=" + "
+                                        if i != int(inputs[0]) - 1:
+                                            str += " + "
                                     str += " = {0}`".format(roll)
 
                                     # Print rolled number
-                                    await send_message(str, bot_chat, )
+                                    await send_message(
+                                        str,
+                                        bot_chat,
+                                    )
                         except ValueError:
-                            await send_message("Please enter a valid dice roll. You can try using: `<dice_number>d<dice_faces>`", bot_chat,)
+                            await send_message(
+                                "Please enter a valid dice roll. You can try using: `<dice_number>d<dice_faces>`",
+                                bot_chat,
+                            )
                 # Pull the latest changes from GitHub
                 elif msg.text.lower().startswith("!pull"):
                     if user in bot_admins:


### PR DESCRIPTION
Closes #85 

## Summary
Added !roll command.
Users can now roll a set of numbers by using any of the following syntax:
`!roll <number>` : Will return same number
`!roll d<faces>` : Rolls a single <faces>-faced dice
`!roll <dice>d<faces>` : Rolls <dice> <faces>-faced dice

<!-- For each item below, replace the [ ] with [x] to confirm that item was completed. -->
## Checklist
- [x] I have read and agree to follow the contributing guidelines and code of conduct in `CONTRIBUTING.md`.
- [x] An issue was made and assigned to me by a maintainer before opening this pull request.
- [x] I have formatted the code as detailed in `CONTRIBUTING.md`.
- [x] I have tested all the code in my pull request, including by running BrainBot as a whole.
